### PR TITLE
Add support for default values inside parameters

### DIFF
--- a/index.js
+++ b/index.js
@@ -173,7 +173,7 @@ function getCommentedFunctionNode(node) {
      * Property              .value                     var obj = { key: function(bar) {} }
      * ReturnStatement       .argument                  return function(foo, bar) {}
      * ArrowFunctionExpression       -                  (foo, bar) => {}
-     * 
+     *
      */
     var nodeTypes = [
         "FunctionDeclaration", "ExpressionStatement", "VariableDeclaration",
@@ -281,12 +281,20 @@ function decorateFunctions(node) {
     // Pair up the function params with the JSDoc params (if they exist)
     funcNode.node.params.forEach(function(param) {
         for (i = 0; i < funcNode.jsdoc.params.length; i++) {
-            if (funcNode.jsdoc.params[i].name === param.name &&
-                    funcNode.jsdoc.params[i].type) {
-                // replace the function param name with the type annotated param
-                param.update(
-                    param.source() + ": " + funcNode.jsdoc.params[i].type
-                );
+            if (funcNode.jsdoc.params[i].type) {
+                if (param.type === 'AssignmentPattern') {
+                    if (funcNode.jsdoc.params[i].name === param.left.name) {
+                        param.update(
+                            param.left.source() + ": " + funcNode.jsdoc.params[i].type + ' = ' + param.right.source()
+                        );
+                    }
+                } else {
+                    if (funcNode.jsdoc.params[i].name === param.name) {
+                        param.update(
+                            param.source() + ": " + funcNode.jsdoc.params[i].type
+                        );
+                    }
+                }
             }
         }
     });

--- a/index.js
+++ b/index.js
@@ -281,19 +281,23 @@ function decorateFunctions(node) {
     // Pair up the function params with the JSDoc params (if they exist)
     funcNode.node.params.forEach(function(param) {
         for (i = 0; i < funcNode.jsdoc.params.length; i++) {
-            if (funcNode.jsdoc.params[i].type) {
-                if (param.type === 'AssignmentPattern') {
-                    if (funcNode.jsdoc.params[i].name === param.left.name) {
-                        param.update(
-                            param.left.source() + ": " + funcNode.jsdoc.params[i].type + ' = ' + param.right.source()
-                        );
-                    }
-                } else {
-                    if (funcNode.jsdoc.params[i].name === param.name) {
-                        param.update(
-                            param.source() + ": " + funcNode.jsdoc.params[i].type
-                        );
-                    }
+            if (!funcNode.jsdoc.params[i].type) {
+                continue;
+            }
+
+            // If default options are set keep the assignment in flow
+            if (param.type === 'AssignmentPattern') {
+                if (funcNode.jsdoc.params[i].name === param.left.name) {
+                    console.log(funcNode.jsdoc.params[i].type);
+                    param.update(
+                        param.left.source() + ": " + funcNode.jsdoc.params[i].type + ' = ' + param.right.source()
+                    );
+                }
+            } else {
+                if (funcNode.jsdoc.params[i].name === param.name) {
+                    param.update(
+                        param.source() + ": " + funcNode.jsdoc.params[i].type
+                    );
                 }
             }
         }

--- a/index.js
+++ b/index.js
@@ -288,9 +288,11 @@ function decorateFunctions(node) {
             // If default options are set keep the assignment in flow
             if (param.type === 'AssignmentPattern') {
                 if (funcNode.jsdoc.params[i].name === param.left.name) {
-                    console.log(funcNode.jsdoc.params[i].type);
+                    // Remove ? if default value is set
+                    var type = funcNode.jsdoc.params[i].type.replace(/^\?/, '');
+
                     param.update(
-                        param.left.source() + ": " + funcNode.jsdoc.params[i].type + ' = ' + param.right.source()
+                        param.left.source() + ": " + type + ' = ' + param.right.source()
                     );
                 }
             } else {

--- a/tests/expected_output/11-optional-params.js
+++ b/tests/expected_output/11-optional-params.js
@@ -8,3 +8,14 @@
 function allTheOptionalForms(foo: string, bar: ?string, baz: ?string, quuz: ?string) : number {
 	return 4;
 };
+
+/**
+ * @param {string} foo
+ * @param {string} [bar]
+ * @param {string=} baz some blurb
+ * @param {string} [quuz=Nope Nope Nope] more blurb
+ * @return {number}
+ */
+function allTheOptionalFormsWithDefaults(foo: string, bar: ?string, baz: ?string = 'Nope', quuz: ?string = 'Nope Nope Nope') : number {
+	return 4;
+};

--- a/tests/expected_output/11-optional-params.js
+++ b/tests/expected_output/11-optional-params.js
@@ -16,6 +16,14 @@ function allTheOptionalForms(foo: string, bar: ?string, baz: ?string, quuz: ?str
  * @param {string} [quuz=Nope Nope Nope] more blurb
  * @return {number}
  */
-function allTheOptionalFormsWithDefaults(foo: string, bar: ?string, baz: ?string = 'Nope', quuz: ?string = 'Nope Nope Nope') : number {
+function allTheOptionalFormsWithDefaults(foo: string, bar: ?string, baz: string = 'Nope', quuz: string = 'Nope Nope Nope') : number {
 	return 4;
+};
+
+/**
+ * @param {number} foo
+ * @return {number}
+ */
+function optionalParamWithWrongJSdoc(foo: number = '4') : number {
+	return Number(foo);
 };

--- a/tests/input/11-optional-params.js
+++ b/tests/input/11-optional-params.js
@@ -8,3 +8,14 @@
 function allTheOptionalForms(foo, bar, baz, quuz) {
 	return 4;
 };
+
+/**
+ * @param {string} foo
+ * @param {string} [bar]
+ * @param {string=} baz some blurb
+ * @param {string} [quuz=Nope Nope Nope] more blurb
+ * @return {number}
+ */
+function allTheOptionalFormsWithDefaults(foo, bar, baz = 'Nope', quuz = 'Nope Nope Nope') {
+	return 4;
+};

--- a/tests/input/11-optional-params.js
+++ b/tests/input/11-optional-params.js
@@ -19,3 +19,11 @@ function allTheOptionalForms(foo, bar, baz, quuz) {
 function allTheOptionalFormsWithDefaults(foo, bar, baz = 'Nope', quuz = 'Nope Nope Nope') {
 	return 4;
 };
+
+/**
+ * @param {number} foo
+ * @return {number}
+ */
+function optionalParamWithWrongJSdoc(foo = '4') {
+	return Number(foo);
+};


### PR DESCRIPTION
`Converts function allTheOptionalFormsWithDefaults(quuz = 'Nope Nope Nope') {}` into
`allTheOptionalFormsWithDefaults(quuz: ?string = 'Nope Nope Nope') {}`