### PR TITLE
Add support for @returns annotation

### DIFF
--- a/index.js
+++ b/index.js
@@ -31,7 +31,7 @@ function extractJsdoc(comment) {
     }).map(jsdocTagToFlowTag);
 
     var returnTags = docAst.tags.filter(function(tag) {
-        return tag.title === "return";
+        return tag.title === "return" || tag.title === "returns";
     }).map(jsdocTagToFlowTag);
 
     var propTags = docAst.tags.filter(function(tag) {

--- a/tests/expected_output/03-stand-alone-function.js
+++ b/tests/expected_output/03-stand-alone-function.js
@@ -6,3 +6,10 @@
 function foo(bar: Array<Foobar>, baz: Function) : number {
     return 42;
 }
+
+/**
+ * @returns {number}
+ */
+function bar() : number {
+    return 42;
+}

--- a/tests/input/03-stand-alone-function.js
+++ b/tests/input/03-stand-alone-function.js
@@ -6,3 +6,10 @@
 function foo(bar, baz) {
     return 42;
 }
+
+/**
+ * @returns {number}
+ */
+function bar() {
+    return 42;
+}


### PR DESCRIPTION
This makes
```
/**
 * @returns {something}
 */
function foo() { ... }
```
transpile correctly into 
```
/**
 * @returns {something}
 */
function foo() : something { ... }
```