### PR TITLE
Added support for babylon parser

### DIFF
--- a/lib/falafel.js
+++ b/lib/falafel.js
@@ -1,6 +1,6 @@
 // This is https://github.com/jareware/node-falafel
 // Using normal 'falafel' from npm isn't producing node.source() correctly; it is giving the entire file.
-var parse = require('esprima').parse;
+
 var objectKeys = Object.keys || function (obj) {
     var keys = [];
     for (var key in obj) keys.push(key);
@@ -28,24 +28,23 @@ module.exports = function (src, opts, fn) {
         delete opts.source;
     }
     src = src === undefined ? opts.source : src;
-    opts.range = true;
     if (typeof src !== 'string') src = String(src);
-    
-    var ast = (opts.parse || parse)(src, opts);
-    
+
+    var ast = opts.parse(src, opts.parseOptions);
+
     var result = {
         chunks : src.split(''),
         toString : function () { return result.chunks.join('') },
         inspect : function () { return result.toString() }
     };
     var index = 0;
-    
+
     (function walk (node, parent) {
         insertHelpers(node, parent, result.chunks);
-        
+
         forEach(objectKeys(node), function (key) {
             if (key === 'parent') return;
-            
+
             var child = node[key];
             if (isArray(child)) {
                 forEach(child, function (c) {
@@ -61,21 +60,26 @@ module.exports = function (src, opts, fn) {
         });
         fn(node);
     })(ast, undefined);
-    
+
     return result;
 };
- 
+
 function insertHelpers (node, parent, chunks) {
-    if (!node.range) return;
-    
+    if (node.hasOwnProperty('start') && node.hasOwnProperty('end')) {
+        node.range = [node.start, node.end];
+    }
+    if (!node.range) {
+        return;
+    }
+
     node.parent = parent;
-    
+
     node.source = function () {
         return chunks.slice(
             node.range[0], node.range[1]
         ).join('');
     };
-    
+
     if (node.update && typeof node.update === 'object') {
         var prev = node.update;
         forEach(objectKeys(prev), function (key) {
@@ -86,7 +90,7 @@ function insertHelpers (node, parent, chunks) {
     else {
         node.update = update;
     }
-    
+
     function update (s) {
         chunks[node.range[0]] = s;
         for (var i = node.range[0] + 1; i < node.range[1]; i++) {

--- a/log.txt
+++ b/log.txt
@@ -1,0 +1,5 @@
+
+> flow-jsdoc@0.2.2 test /Volumes/MAC_EXTRA/Projects/tmp/flow-jsdoc
+> node tests/runner.js
+
+0 test failures out of 11 tests.

--- a/package.json
+++ b/package.json
@@ -5,7 +5,6 @@
   "main": "index.js",
   "dependencies": {
     "doctrine": "^0.6.4",
-    "esprima": "^3.0.0",
     "glob": "^5.0.14",
     "mkdirp": "^0.5.1",
     "nopt": "^3.0.3"
@@ -13,7 +12,13 @@
   "repository": {
     "url": "https://github.com/Kegsay/flow-jsdoc"
   },
-  "devDependencies": {},
+  "devDependencies": {
+    "babylon": "^6.15.0",
+    "esprima": "^3.0.0"
+  },
+  "peerDependencies": {
+    "esprima": "3.x.x"
+  },
   "scripts": {
     "test": "node tests/runner.js"
   },


### PR DESCRIPTION
Made some changes to support different ast providers. I only made it work with babylon and esprima.

We could add the options to make Line & commentLine dynamic as an option.
esprima says "line" and babylon "CommentLine" (but there are more differences)