### PR TITLE
Allow fat arrow functions as part of export

### DIFF
--- a/index.js
+++ b/index.js
@@ -206,7 +206,12 @@ function getCommentedFunctionNode(node) {
             funcNode = node.argument;
             break;
         case "ExportNamedDeclaration":
-            funcNode = node.declaration;
+            var declaration = node.declaration;
+            if (declaration.type === 'VariableDeclaration') {
+                funcNode = declaration.declarations[0].init;
+            } else {
+                funcNode = declaration
+            }
             break;
     }
     var funcNodeTypes = ["FunctionDeclaration", "FunctionExpression", "ArrowFunctionExpression"];

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "index.js",
   "dependencies": {
     "doctrine": "^0.6.4",
-    "esprima": "^3.0.0",
+    "esprima": "^4.0.0",
     "glob": "^5.0.14",
     "mkdirp": "^0.5.1",
     "nopt": "^3.0.3"

--- a/package.json
+++ b/package.json
@@ -1,11 +1,11 @@
 {
   "name": "flow-jsdoc",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "description": "Represent flow type annotations with JSDoc syntax",
   "main": "index.js",
   "dependencies": {
     "doctrine": "^0.6.4",
-    "esprima": "^3.0.0",
+    "esprima": "^4.0.0",
     "glob": "^5.0.14",
     "mkdirp": "^0.5.1",
     "nopt": "^3.0.3"

--- a/tests/expected_output/13-es6-export-const-fat-arrow.js
+++ b/tests/expected_output/13-es6-export-const-fat-arrow.js
@@ -1,0 +1,8 @@
+/**
+ * @param {Foobar[]} bar A foobar array
+ * @param {Function} baz
+ * @return {number}
+ */
+export const foo = (bar: Array<Foobar>, baz: Function) : number => {
+    return 42;
+}

--- a/tests/input/13-es6-export-const-fat-arrow.js
+++ b/tests/input/13-es6-export-const-fat-arrow.js
@@ -1,0 +1,8 @@
+/**
+ * @param {Foobar[]} bar A foobar array
+ * @param {Function} baz
+ * @return {number}
+ */
+export const foo = (bar, baz) => {
+    return 42;
+}


### PR DESCRIPTION
input:
```javascript
/**
 * @param {Foobar[]} bar A foobar array
 * @param {Function} baz
 * @return {number}
 */
export const foo = (bar, baz) => {
    return 42;
}
```
output:
```javascript
/**
 * @param {Foobar[]} bar A foobar array
 * @param {Function} baz
 * @return {number}
 */
export const foo = (bar: Array<Foobar>, baz: Function) : number => {
    return 42;
}
```

This pull request also updates `esprima` to `4.0.0`, which adds the ability to handle es2017 `async` functions.